### PR TITLE
Improved compatibility for more Android Studio versions and add support for latest compose compiler

### DIFF
--- a/AndroidWorkshop/ComposeDynamicIsland/app/build.gradle
+++ b/AndroidWorkshop/ComposeDynamicIsland/app/build.gradle
@@ -37,7 +37,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.2.0-beta01'
+        kotlinCompilerExtensionVersion '1.3.2'
     }
     packagingOptions {
         resources {
@@ -47,18 +47,37 @@ android {
 }
 
 dependencies {
+    def composeBom = platform('androidx.compose:compose-bom:2022.10.00')
+    implementation composeBom
+    androidTestImplementation composeBom
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.6.0'
-    implementation "androidx.compose.ui:ui:$compose_ui_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
-    implementation 'androidx.compose.material:material:1.3.0-rc01'
-    implementation "androidx.compose.material:material-icons-extended:$compose_ui_version"
+    // Choose one of the following:
+    // Material Design 3
+    implementation 'androidx.compose.material3:material3'
+
+    // Optional - Included automatically by material, only add when you need
+    // the icons but not the material library (e.g. when using Material3 or a
+    // custom design system based on Foundation)
+    implementation 'androidx.compose.material:material-icons-core'
+    // Optional - Add full set of material icons
+    implementation 'androidx.compose.material:material-icons-extended'
+
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+
+    // Optional - Integration with activities
+    implementation 'androidx.activity:activity-compose:1.6.1'
+    // Optional - Integration with ViewModels
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1'
+    // Optional - Integration with LiveData
+    implementation 'androidx.compose.runtime:runtime-livedata'
+
+    // Test
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_ui_version"
 }

--- a/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/DynamicIsland.kt
+++ b/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/DynamicIsland.kt
@@ -18,13 +18,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FastRewind
 import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -156,7 +156,7 @@ private fun PlayerController(modifier: Modifier) {
                     .height(10.dp)
                     .fillMaxWidth(0.6f),
                 color = Color.White,
-                backgroundColor = Color.Gray,
+                trackColor = Color.Gray,
             )
             Text("-1:00", color = Color.White)
         }

--- a/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/MainActivity.kt
+++ b/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/MainActivity.kt
@@ -6,21 +6,18 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.compose.dynamicisland.ui.theme.ComposeDynamicIslandTheme
 
@@ -32,7 +29,7 @@ class MainActivity : ComponentActivity() {
                 // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colors.background
+                    color = MaterialTheme.colorScheme.background
                 ) {
 
                     var state: IslandType by remember {

--- a/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/ui/theme/Shape.kt
+++ b/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/ui/theme/Shape.kt
@@ -1,7 +1,7 @@
 package com.compose.dynamicisland.ui.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Shapes
+import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
 val Shapes = Shapes(

--- a/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/ui/theme/Theme.kt
+++ b/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/ui/theme/Theme.kt
@@ -1,21 +1,21 @@
 package com.compose.dynamicisland.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 
-private val DarkColorPalette = darkColors(
+private val DarkColorPalette = darkColorScheme(
     primary = Purple200,
-    primaryVariant = Purple700,
-    secondary = Teal200
+    secondary = Purple700,/**/
+    tertiary = Teal200
 )
 
-private val LightColorPalette = lightColors(
+private val LightColorPalette = lightColorScheme(
     primary = Purple500,
-    primaryVariant = Purple700,
-    secondary = Teal200
+    secondary = Purple700,
+    tertiary = Teal200
 
     /* Other default colors to override
     background = Color.White,
@@ -39,7 +39,7 @@ fun ComposeDynamicIslandTheme(
     }
 
     MaterialTheme(
-        colors = colors,
+        colorScheme = colors,
         typography = Typography,
         shapes = Shapes,
         content = content

--- a/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/ui/theme/Type.kt
+++ b/AndroidWorkshop/ComposeDynamicIsland/app/src/main/java/com/compose/dynamicisland/ui/theme/Type.kt
@@ -1,6 +1,6 @@
 package com.compose.dynamicisland.ui.theme
 
-import androidx.compose.material.Typography
+import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -8,7 +8,7 @@ import androidx.compose.ui.unit.sp
 
 // Set of Material typography styles to start with
 val Typography = Typography(
-    body1 = TextStyle(
+    bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp

--- a/AndroidWorkshop/ComposeDynamicIsland/build.gradle
+++ b/AndroidWorkshop/ComposeDynamicIsland/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     ext {
-        compose_ui_version = '1.3.0-rc01'
+        compose_ui_version = '1.3.2'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.2.2' apply false
     id 'com.android.library' version '7.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }

--- a/AndroidWorkshop/ComposeDynamicIsland/build.gradle
+++ b/AndroidWorkshop/ComposeDynamicIsland/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.0-alpha05' apply false
-    id 'com.android.library' version '8.0.0-alpha05' apply false
+    id 'com.android.application' version '7.2.2' apply false
+    id 'com.android.library' version '7.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
 }


### PR DESCRIPTION
Include two adaptions:

1) Android Studio Chipmunk as the minimum supported version. Refer to [Android Gradle plugin and Android Studio compatibility](https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility)

2) Compile with latest [Compose Compiler 1.3.2](https://developer.android.com/jetpack/androidx/releases/compose#declaring_dependencies) and adapt to [Material Design 3](https://developer.android.com/jetpack/compose/designsystems/material2-material3)